### PR TITLE
添加注解处理器，自动生成 spring.factories 元数据文件

### DIFF
--- a/buildSrc/src/main/java/com/jcohy/boot/build/JcohyModulePlugin.java
+++ b/buildSrc/src/main/java/com/jcohy/boot/build/JcohyModulePlugin.java
@@ -6,6 +6,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.plugins.JavaLibraryPlugin;
+import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.PluginContainer;
 
 import com.jcohy.convention.conventions.ConventionsPlugin;
@@ -40,5 +41,7 @@ public class JcohyModulePlugin implements Plugin<Project> {
         project.getConfigurations().getByName("dependencyManagement", (dependencyManagement) -> {
             dependencyManagement.getDependencies().add(parent);
         });
+
+//		project.getDependencies().add(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, project.getDependencies().project(Collections.singletonMap("path","jcohy-boot-test")));
     }
 }

--- a/idea/JcohyCodeStyle.xml
+++ b/idea/JcohyCodeStyle.xml
@@ -1,0 +1,130 @@
+<code_scheme name="JcohyCodeStyle" version="173">
+	<option name="AUTODETECT_INDENTS" value="false"/>
+	<option name="OTHER_INDENT_OPTIONS">
+		<value>
+			<option name="USE_TAB_CHARACTER" value="true"/>
+		</value>
+	</option>
+	<option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="50"/>
+	<option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="500"/>
+	<option name="IMPORT_LAYOUT_TABLE">
+		<value>
+			<package name="java" withSubpackages="true" static="false"/>
+			<emptyLine/>
+			<package name="javax" withSubpackages="true" static="false"/>
+			<emptyLine/>
+			<package name="" withSubpackages="true" static="false"/>
+			<emptyLine/>
+			<package name="org.springframework" withSubpackages="true" static="false"/>
+			<emptyLine/>
+			<package name="" withSubpackages="true" static="true"/>
+		</value>
+	</option>
+	<option name="RIGHT_MARGIN" value="90"/>
+	<option name="ENABLE_JAVADOC_FORMATTING" value="false"/>
+	<option name="JD_ALIGN_PARAM_COMMENTS" value="false"/>
+	<option name="JD_ALIGN_EXCEPTION_COMMENTS" value="false"/>
+	<option name="JD_KEEP_EMPTY_LINES" value="false"/>
+	<GroovyCodeStyleSettings>
+		<option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="500"/>
+		<option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="500"/>
+		<option name="IMPORT_LAYOUT_TABLE">
+			<value>
+				<package name="java" withSubpackages="true" static="false" />
+				<emptyLine />
+				<package name="javax" withSubpackages="true" static="false" />
+				<emptyLine />
+				<package name="" withSubpackages="true" static="false" />
+				<emptyLine />
+				<package name="org.springframework" withSubpackages="true" static="false" />
+				<emptyLine />
+				<package name="com.jcohy" withSubpackages="true" static="false" />
+				<emptyLine />
+				<package name="" withSubpackages="true" static="true" />
+			</value>
+		</option>
+	</GroovyCodeStyleSettings>
+	<JavaCodeStyleSettings>
+		<option name="CLASS_NAMES_IN_JAVADOC" value="3"/>
+		<option name="INSERT_INNER_CLASS_IMPORTS" value="true"/>
+		<option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="50"/>
+		<option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="500"/>
+		<option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
+			<value/>
+		</option>
+		<option name="IMPORT_LAYOUT_TABLE">
+			<value>
+				<package name="java" withSubpackages="true" static="false" />
+				<emptyLine />
+				<package name="javax" withSubpackages="true" static="false" />
+				<emptyLine />
+				<package name="" withSubpackages="true" static="false" />
+				<emptyLine />
+				<package name="org.springframework" withSubpackages="true" static="false" />
+				<emptyLine />
+				<package name="com.jcohy" withSubpackages="true" static="false" />
+				<emptyLine />
+				<package name="" withSubpackages="true" static="true" />
+			</value>
+		</option>
+		<option name="ENABLE_JAVADOC_FORMATTING" value="false"/>
+		<option name="JD_ALIGN_PARAM_COMMENTS" value="false"/>
+		<option name="JD_ALIGN_EXCEPTION_COMMENTS" value="false"/>
+		<option name="JD_KEEP_INVALID_TAGS" value="false"/>
+		<option name="JD_KEEP_EMPTY_LINES" value="false"/>
+	</JavaCodeStyleSettings>
+	<JetCodeStyleSettings>
+		<option name="PACKAGES_TO_USE_STAR_IMPORTS">
+			<value>
+				<package name="java.util" withSubpackages="false" static="false"/>
+				<package name="kotlinx.android.synthetic" withSubpackages="false"
+						 static="false"/>
+			</value>
+		</option>
+		<option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="20"/>
+		<option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="20"/>
+	</JetCodeStyleSettings>
+	<XML>
+		<option name="XML_LEGACY_SETTINGS_IMPORTED" value="true"/>
+	</XML>
+	<editorconfig>
+		<option name="ENABLED" value="false"/>
+	</editorconfig>
+	<codeStyleSettings language="Groovy">
+		<indentOptions>
+			<option name="USE_TAB_CHARACTER" value="true"/>
+		</indentOptions>
+	</codeStyleSettings>
+	<codeStyleSettings language="JAVA">
+		<option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1"/>
+		<option name="BLANK_LINES_AROUND_FIELD" value="1"/>
+		<option name="BLANK_LINES_AROUND_FIELD_IN_INTERFACE" value="1"/>
+		<option name="ELSE_ON_NEW_LINE" value="true"/>
+		<option name="CATCH_ON_NEW_LINE" value="true"/>
+		<option name="FINALLY_ON_NEW_LINE" value="true"/>
+		<option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
+		<option name="SPACE_WITHIN_ARRAY_INITIALIZER_BRACES" value="true"/>
+		<option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true"/>
+		<option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true"/>
+		<option name="KEEP_SIMPLE_CLASSES_IN_ONE_LINE" value="true"/>
+		<option name="KEEP_MULTIPLE_EXPRESSIONS_IN_ONE_LINE" value="true"/>
+		<indentOptions>
+			<option name="USE_TAB_CHARACTER" value="true"/>
+		</indentOptions>
+	</codeStyleSettings>
+	<codeStyleSettings language="JSON">
+		<indentOptions>
+			<option name="TAB_SIZE" value="2"/>
+		</indentOptions>
+	</codeStyleSettings>
+	<codeStyleSettings language="XML">
+		<indentOptions>
+			<option name="USE_TAB_CHARACTER" value="true"/>
+		</indentOptions>
+	</codeStyleSettings>
+	<codeStyleSettings language="kotlin">
+		<indentOptions>
+			<option name="USE_TAB_CHARACTER" value="true"/>
+		</indentOptions>
+	</codeStyleSettings>
+</code_scheme>

--- a/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/AbstractConfigureAnnotationProcessor.java
+++ b/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/AbstractConfigureAnnotationProcessor.java
@@ -1,0 +1,113 @@
+package com.jcohy.boot.configuration.processor;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Set;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.tools.Diagnostic;
+
+/**
+ * 描述: 注解处理器.
+ * <p>
+ * Copyright © 2022
+ * <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
+ * </p>
+ *
+ * @author jiac
+ * @version 2022.04.0 2022/4/20:11:13
+ * @since 2022.04.0
+ */
+public abstract class AbstractConfigureAnnotationProcessor extends AbstractProcessor {
+
+    /**
+     * 返回注解支持的可选项.
+     * @return set&lt;String&gt;
+     */
+    @Override
+    public Set<String> getSupportedOptions() {
+        return super.getSupportedOptions();
+    }
+
+    /**
+     * 返回此 Processor 支持的注解类型的名称。结果元素可能是某一受支持注解类型的规范（完全限定）名称。 它也可能是 ” name.” 形式的名称，表示所有以 ”
+     * name.” 开头的规范名称的注解类型集合。 最后，自身表示所有注解类型的集合，包括空集。注意，Processor 不应声明
+     * “*”，除非它实际处理了所有文件；声明不必要的注释可能导致在某些环境中的性能下降.
+     * @return 返回Processor支持的注解类型名称
+     */
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+        return super.getSupportedAnnotationTypes();
+    }
+
+    /**
+     * 返回此注解 Processor 支持的最新的源版本，该方法可以通过注解 @SupportedSourceVersion 指定.
+     * @return /
+     */
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latestSupported();
+    }
+
+    /**
+     * 初始化，该方法主要用于一些初始化的操作，通过该方法的参数 ProcessingEnvironment 可以获取一些列有用的工具类.
+     * @param processingEnv 初始化
+     */
+    @Override
+    public synchronized void init(ProcessingEnvironment processingEnv) {
+        super.init(processingEnv);
+    }
+
+    /**
+     * 注解处理器的核心方法，处理具体的注解.
+     * @param annotations annotations
+     * @param roundEnv processingEnv
+     * @return boolean
+     */
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        try {
+            return processImpl(annotations, roundEnv);
+        }
+        catch (Exception ex) {
+            fatalError(ex);
+            return false;
+        }
+    }
+
+    /**
+     * 注解处理 实现类.
+     * @param annotations annotations
+     * @param roundEnv roundEnv
+     * @return boolean
+     */
+    protected abstract boolean processImpl(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv);
+
+    protected void log(String msg) {
+        if (processingEnv.getOptions().containsKey("debug")) {
+            processingEnv.getMessager().printMessage(Diagnostic.Kind.NOTE, msg);
+        }
+    }
+
+    protected void error(String msg, Element element, AnnotationMirror annotation) {
+        processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, msg, element, annotation);
+    }
+
+    protected void fatalError(Exception e) {
+        // We don't allow exceptions of any kind to propagate to the compiler
+        StringWriter writer = new StringWriter();
+        e.printStackTrace(new PrintWriter(writer));
+        fatalError(writer.toString());
+    }
+
+    protected void fatalError(String msg) {
+        processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "FATAL ERROR: " + msg);
+    }
+
+}

--- a/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/JavaSpiServiceProcessor.java
+++ b/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/JavaSpiServiceProcessor.java
@@ -1,0 +1,235 @@
+package com.jcohy.boot.configuration.processor;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.LineNumberReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.tools.FileObject;
+import javax.tools.StandardLocation;
+
+import com.jcohy.boot.configuration.processor.utils.Constants;
+import com.jcohy.boot.configuration.processor.utils.Elements;
+import com.jcohy.boot.configuration.processor.utils.MultiMapSet;
+import com.jcohy.boot.configuration.processor.value.ValueExtractor;
+
+/**
+ * 描述: .
+ * <p>
+ * Copyright © 2022
+ * <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
+ * </p>
+ *
+ * @author jiac
+ * @version 2022.04.0 2022/4/20:12:08
+ * @since 2022.04.0
+ */
+@SupportedAnnotationTypes({ "com.jcohy.boot.configuration.processor.annotations.JavaSpiService" })
+public class JavaSpiServiceProcessor extends AbstractConfigureAnnotationProcessor {
+
+    private final Map<String, String> annotations;
+
+    private final Map<String, ValueExtractor> valueExtractors;
+
+    /**
+     * spi 服务集合，key 接口 -> value 实现列表.
+     */
+    private final MultiMapSet<String, String> providers = new MultiMapSet<>();
+
+    public JavaSpiServiceProcessor() {
+        Map<String, String> annotations = new LinkedHashMap<>();
+        addAnnotations(annotations);
+        this.annotations = Collections.unmodifiableMap(annotations);
+        Map<String, ValueExtractor> valueExtractors = new LinkedHashMap<>();
+        addValueExtractors(valueExtractors);
+        this.valueExtractors = Collections.unmodifiableMap(valueExtractors);
+    }
+
+    /**
+     * 从服务文件中读取 服务类.
+     * @param input not {@code null}. Closed after use.
+     * @return a not {@code null Set} of service class names.
+     * @throws IOException ex
+     */
+    public static Set<String> readServiceFile(InputStream input) throws IOException {
+        HashSet<String> serviceClasses = new HashSet<String>();
+
+        try (LineNumberReader reader = new LineNumberReader(new InputStreamReader(input, StandardCharsets.UTF_8))) {
+            reader.lines().forEach((line) -> {
+                int commentStart = line.indexOf('#');
+                if (commentStart >= 0) {
+                    line = line.substring(0, commentStart);
+                }
+                line = line.trim();
+                if (!line.isEmpty()) {
+                    serviceClasses.add(line);
+                }
+            });
+            return serviceClasses;
+        }
+        // try (InputStreamReader isr = new InputStreamReader(input,
+        // StandardCharsets.UTF_8);
+        //
+        // BufferedReader r = new BufferedReader(isr)) {
+        // String line;
+        // while ((line = r.readLine()) != null) {
+        // int commentStart = line.indexOf('#');
+        // if (commentStart >= 0) {
+        // line = line.substring(0, commentStart);
+        // }
+        // line = line.trim();
+        // if (!line.isEmpty()) {
+        // serviceClasses.add(line);
+        // }
+        // }
+        // return serviceClasses;
+        // }
+    }
+
+    /**
+     * 将服务类编写进服务文件中.
+     * @param output not {@code null}. Not closed after use.
+     * @param services a not {@code null Collection} of service class names.
+     * @throws IOException ex
+     */
+    public static void writeServiceFile(Collection<String> services, OutputStream output) throws IOException {
+        BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(output, StandardCharsets.UTF_8));
+        for (String service : services) {
+            writer.write(service);
+            writer.newLine();
+        }
+        writer.flush();
+    }
+
+    private void addAnnotations(Map<String, String> annotations) {
+        annotations.put("JavaSpiService", "com.jcohy.boot.configuration.processor.annotations.JavaSpiService");
+    }
+
+    private void addValueExtractors(Map<String, ValueExtractor> attributes) {
+        attributes.put("JavaSpiService", ValueExtractor.allFrom("value"));
+    }
+
+    @Override
+    protected boolean processImpl(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        for (Map.Entry<String, String> entry : this.annotations.entrySet()) {
+            processImpl(roundEnv, entry.getKey(), entry.getValue());
+        }
+        if (roundEnv.processingOver()) {
+            try {
+                writeProperties();
+            }
+            catch (Exception ex) {
+                throw new IllegalStateException("Failed to write metadata", ex);
+            }
+        }
+        return false;
+    }
+
+    private void processImpl(RoundEnvironment roundEnv, String propertyKey, String annotationName) {
+        TypeElement annotationType = this.processingEnv.getElementUtils().getTypeElement(annotationName);
+        if (annotationType != null) {
+            for (Element element : roundEnv.getElementsAnnotatedWith(annotationType)) {
+                processElement(element, propertyKey, annotationName);
+            }
+        }
+    }
+
+    private void processElement(Element element, String propertyKey, String annotationName) {
+        try {
+            String qualifiedName = Elements.getQualifiedName(element);
+            AnnotationMirror annotation = getAnnotation(element, annotationName);
+            if (qualifiedName != null && annotation != null) {
+                List<Object> interfaces = getValues(propertyKey, annotation);
+                log("provider interface: " + interfaces);
+                log("provider implementer: " + qualifiedName);
+                this.providers.put(interfaces.get(0).toString(), qualifiedName);
+            }
+        }
+        catch (Exception ex) {
+            throw new IllegalStateException("Error processing configuration meta-data on " + element, ex);
+        }
+    }
+
+    private AnnotationMirror getAnnotation(Element element, String type) {
+        if (element != null) {
+            for (AnnotationMirror annotation : element.getAnnotationMirrors()) {
+                if (type.equals(annotation.getAnnotationType().toString())) {
+                    return annotation;
+                }
+            }
+        }
+        return null;
+    }
+
+    private List<Object> getValues(String propertyKey, AnnotationMirror annotation) {
+        ValueExtractor extractor = this.valueExtractors.get(propertyKey);
+        if (extractor == null) {
+            return Collections.emptyList();
+        }
+        return extractor.getValues(annotation);
+    }
+
+    /**
+     * 输出文件.
+     * @throws IOException /
+     */
+    private void writeProperties() throws IOException {
+        Filer filer = processingEnv.getFiler();
+        for (String providerInterface : this.providers.keySet()) {
+            String resourceFile = Constants.SERVICE_RESOURCE_LOCATION + providerInterface;
+            log("Working on resource file: " + resourceFile);
+            try {
+                SortedSet<String> allServices = new TreeSet<>();
+                try {
+                    FileObject existingFile = filer.getResource(StandardLocation.CLASS_OUTPUT, "", resourceFile);
+                    log("Looking for existing resource file at " + existingFile.toUri());
+                    Set<String> oldServices = readServiceFile(existingFile.openInputStream());
+                    log("Existing service entries: " + oldServices);
+                    allServices.addAll(oldServices);
+                }
+                catch (IOException ex) {
+                    log("Resource file did not already exist.");
+                }
+
+                Set<String> newServices = new HashSet<>(this.providers.get(providerInterface));
+                if (allServices.containsAll(newServices)) {
+                    log("No new service entries being added.");
+                    return;
+                }
+
+                allServices.addAll(newServices);
+                log("New service file contents: " + allServices);
+                FileObject fileObject = filer.createResource(StandardLocation.CLASS_OUTPUT, "", resourceFile);
+                OutputStream out = fileObject.openOutputStream();
+                writeServiceFile(allServices, out);
+                out.close();
+                log("Wrote to: " + fileObject.toUri());
+            }
+            catch (IOException ex) {
+                fatalError("Unable to create " + resourceFile + ", " + ex);
+                return;
+            }
+
+        }
+    }
+
+}

--- a/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/SpringFactoriesProcessor.java
+++ b/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/SpringFactoriesProcessor.java
@@ -1,0 +1,253 @@
+package com.jcohy.boot.configuration.processor;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
+
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+import javax.tools.FileObject;
+import javax.tools.StandardLocation;
+
+import com.jcohy.boot.configuration.processor.utils.Constants;
+import com.jcohy.boot.configuration.processor.utils.Elements;
+import com.jcohy.boot.configuration.processor.utils.MultiMapSet;
+import com.jcohy.boot.configuration.processor.utils.Types;
+import com.jcohy.boot.configuration.processor.value.ValueExtractor;
+
+/**
+ * 描述: .
+ * <p>
+ * Copyright © 2022
+ * <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
+ * </p>
+ *
+ * @author jiac
+ * @version 2022.04.0 2022/4/20:12:29
+ * @since 2022.04.0
+ */
+@SupportedAnnotationTypes({ "*" })
+public class SpringFactoriesProcessor extends AbstractConfigureAnnotationProcessor {
+
+    /**
+     * key 为注解，value 为注解所需要实现的接口.为了避免在类上的注解和实现的接口不匹配.
+     */
+    private final Map<String, String> annotations;
+
+    private final Map<String, ValueExtractor> valueExtractors;
+
+    private final MultiMapSet<String, String> factories = new MultiMapSet<>();
+
+    public SpringFactoriesProcessor() {
+        Map<String, String> annotations = new LinkedHashMap<>();
+        addAnnotations(annotations);
+        this.annotations = Collections.unmodifiableMap(annotations);
+        Map<String, ValueExtractor> valueExtractors = new LinkedHashMap<>();
+        addValueExtractors(valueExtractors);
+        this.valueExtractors = Collections.unmodifiableMap(valueExtractors);
+    }
+
+    private void addAnnotations(Map<String, String> annotations) {
+        annotations.put("com.jcohy.boot.configuration.processor.annotations.SpringApplicationContextInitializer",
+                "org.springframework.context.ApplicationContextInitializer");
+        annotations.put("com.jcohy.boot.configuration.processor.annotations.SpringApplicationListener",
+                "org.springframework.context.ApplicationListener");
+        annotations.put("com.jcohy.boot.configuration.processor.annotations.SpringFailureAnalyzer",
+                "org.springframework.boot.diagnostics.FailureAnalyzer");
+        annotations.put("org.springframework.stereotype.Component",
+                "org.springframework.boot.autoconfigure.EnableAutoConfiguration");
+    }
+
+    private void addValueExtractors(Map<String, ValueExtractor> attributes) {
+    }
+
+    @Override
+    protected boolean processImpl(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+
+        processAnnotations(annotations, roundEnv);
+
+        if (roundEnv.processingOver()) {
+            try {
+                writeProperties();
+            }
+            catch (Exception ex) {
+                throw new IllegalStateException("Failed to write metadata", ex);
+            }
+        }
+        log("SpringFactoriesProcessor processor end ");
+        return false;
+    }
+
+    /**
+     * 注解处理.
+     * @param annotations 注解
+     * @param roundEnv roundEnv
+     */
+    private void processAnnotations(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        // roundEnv.getRootElements() 会返回工程中所有的 Class,在实际应用中需要对各个 Class 先做过滤以提高效率，避免对每个
+        // Class 的内容都进行扫描
+        Set<TypeElement> typeElements = roundEnv.getRootElements().stream().filter(this::isClassOrInterface)
+                .filter((element) -> element instanceof TypeElement).map((element) -> (TypeElement) element)
+                .collect(Collectors.toSet());
+
+        // 如果为空直接跳出
+        if (typeElements.isEmpty()) {
+            log("Annotations elementSet is isEmpty");
+            return;
+        }
+
+        log("All typeElements: " + typeElements.toString());
+
+        for (TypeElement typeElement : typeElements) {
+            for (Map.Entry<String, String> entry : this.annotations.entrySet()) {
+                if (checkImplementer(typeElement, typeElement.getInterfaces())
+                        && checkAnnotation(typeElement, entry.getKey())) {
+                    log("add new spring.factories factoryName：" + typeElement.getQualifiedName().toString());
+                    this.factories.put(entry.getValue(), Elements.getBinaryName(typeElement));
+                }
+            }
+        }
+    }
+
+    /**
+     * 检查元素类型是否是接口或类.
+     * @param e 元素
+     * @return {@code true} 是接口或类
+     */
+    private boolean isClassOrInterface(Element e) {
+        ElementKind kind = e.getKind();
+        return kind == ElementKind.CLASS || kind == ElementKind.INTERFACE;
+    }
+
+    /**
+     * 注解检查处理，主要是判断是否是组合注解（不包含 java 元注解）.
+     * @param annotationTypeElement annotationTypeElement
+     * @param annotationName 注解名
+     * @return /
+     */
+    private boolean checkAnnotation(Element annotationTypeElement, String annotationName) {
+        List<? extends AnnotationMirror> allAnnotationMirrors = processingEnv.getElementUtils()
+                .getAllAnnotationMirrors(annotationTypeElement);
+        log("allAnnotationMirrors ======" + allAnnotationMirrors.toString());
+        for (AnnotationMirror annotation : allAnnotationMirrors) {
+
+            // 如果是普通的单注解，eg：@Component
+            if (checkAnnotation(annotationName, annotation)) {
+                return true;
+            }
+            // 处理组合注解
+            Element element = annotation.getAnnotationType().asElement();
+            // 如果是 java 元注解，不处理，继续循环
+            if (element.toString().startsWith("java.lang")) {
+                continue;
+            }
+            // eg: @Configuration
+            if (checkAnnotation(element, annotationName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * 判断注解名和注解是不是同一个.
+     * @param annotationFullName 注解名
+     * @param annotation 注解类型
+     * @return /
+     */
+    private boolean checkAnnotation(String annotationFullName, AnnotationMirror annotation) {
+        return annotationFullName.equals(annotation.getAnnotationType().toString());
+    }
+
+    private AnnotationMirror getAnnotation(Element element, String type) {
+        if (element != null) {
+            for (AnnotationMirror annotation : element.getAnnotationMirrors()) {
+                if (type.equals(annotation.getAnnotationType().toString())) {
+                    return annotation;
+                }
+            }
+        }
+        return null;
+    }
+
+    private List<Object> getValues(String propertyKey, AnnotationMirror annotation) {
+        ValueExtractor extractor = this.valueExtractors.get(propertyKey);
+        if (extractor == null) {
+            return Collections.emptyList();
+        }
+        return extractor.getValues(annotation);
+    }
+
+    /**
+     * 检查被注解的类实现的接口是否和相对应的注解匹配. eg: 使用
+     * com.jcohy.boot.configuration.processor.annotations.SpringApplicationContextInitializer
+     * 注解的必须实现 org.springframework.context.ApplicationContextInitializer
+     * @param annotationTypeElement 被注解的类。
+     * @param interfaces 接口
+     * @return {@code true} 匹配
+     */
+    private boolean checkImplementer(TypeElement annotationTypeElement, List<? extends TypeMirror> interfaces) {
+        for (AnnotationMirror annotation : annotationTypeElement.getAnnotationMirrors()) {
+            String annotationType = annotation.getAnnotationType().toString();
+
+            // 如果为其他注解，注解返回 true，不进行校验
+            if (!annotationType.startsWith("com.jcohy.boot")) {
+                return true;
+            }
+            // 如果元素上的注解为 org.springframework 不做接口实现与 AutoService 注解上的接口是否一致
+            if (this.annotations.containsKey(annotationType)
+                    && Types.contain(interfaces, this.annotations.get(annotationType))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * 写出 spring.factories 文件.
+     * @throws IOException /
+     */
+    private void writeProperties() throws IOException {
+
+        if (!this.factories.isEmpty()) {
+            Filer filer = this.processingEnv.getFiler();
+            FileObject file = filer.createResource(StandardLocation.CLASS_OUTPUT, "",
+                    Constants.SPRING_FACTORY_RESOURCE_LOCATION);
+            log("Starting write spring.factories file: " + file);
+            try (BufferedWriter writer = new BufferedWriter(
+                    new OutputStreamWriter(file.openOutputStream(), StandardCharsets.UTF_8))) {
+                Set<String> keySet = this.factories.keySet();
+                for (String key : keySet) {
+                    Set<String> values = this.factories.get(key);
+                    if (values == null || values.isEmpty()) {
+                        continue;
+                    }
+                    writer.write(key);
+                    writer.write("=\\\n  ");
+                    StringJoiner joiner = new StringJoiner(",\\\n  ");
+                    for (String value : values) {
+                        joiner.add(value);
+                    }
+                    writer.write(joiner.toString());
+                    writer.newLine();
+                }
+            }
+            log("end write spring.factories file: " + file);
+        }
+    }
+
+}

--- a/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/annotations/JavaSpiService.java
+++ b/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/annotations/JavaSpiService.java
@@ -23,4 +23,7 @@ package com.jcohy.boot.configuration.processor.annotations;
  */
 public @interface JavaSpiService {
 
+	Class<?>[] value();
+
+	String name() default "";
 }

--- a/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/annotations/JavaSpiService.java
+++ b/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/annotations/JavaSpiService.java
@@ -23,7 +23,8 @@ package com.jcohy.boot.configuration.processor.annotations;
  */
 public @interface JavaSpiService {
 
-	Class<?>[] value();
+    Class<?>[] value();
 
-	String name() default "";
+    String name() default "";
+
 }

--- a/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/annotations/JavaSpiService.java
+++ b/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/annotations/JavaSpiService.java
@@ -1,0 +1,26 @@
+package com.jcohy.boot.configuration.processor.annotations;
+
+/**
+ * 描述: {@link java.util.ServiceLoader} 中描述的服务提供商的提供的注解一样，此注解处理器可以自动生成 被注解的类的配置文件，然后被 *
+ * {@link java.util.ServiceLoader#load(Class)} 加载.
+ *
+ * <p>
+ * 被注解的类必须符合服务提供商规范
+ * <ul>
+ * <li>不能是内部类和匿名类，必须要有确定的名称
+ * <li>必须要有公共的，可调用的无参构造函数
+ * <li>使用这个注解的类必须要实现value参数定义的接口 { @code value()}
+ * </ul>
+ *
+ * <p>
+ * Copyright © 2022
+ * <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
+ * </p>
+ *
+ * @author jiac
+ * @version 2022.04.0 2022/4/20:11:11
+ * @since 2022.04.0
+ */
+public @interface JavaSpiService {
+
+}

--- a/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/annotations/SpringApplicationContextInitializer.java
+++ b/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/annotations/SpringApplicationContextInitializer.java
@@ -1,0 +1,23 @@
+package com.jcohy.boot.configuration.processor.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * 描述: 用于在 spring.factories 文件中生成 .
+ * <p>
+ * Copyright © 2022
+ * <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
+ * </p>
+ *
+ * @author jiac
+ * @version 2022.04.0 2022/4/20:11:10
+ * @since 2022.04.0
+ */
+@Documented
+@Retention(java.lang.annotation.RetentionPolicy.SOURCE)
+@Target(java.lang.annotation.ElementType.TYPE)
+public @interface SpringApplicationContextInitializer {
+
+}

--- a/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/annotations/SpringApplicationListener.java
+++ b/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/annotations/SpringApplicationListener.java
@@ -1,0 +1,16 @@
+package com.jcohy.boot.configuration.processor.annotations;
+
+/**
+ * 描述: .
+ * <p>
+ * Copyright © 2022
+ * <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
+ * </p>
+ *
+ * @author jiac
+ * @version 2022.04.0 2022/4/20:11:10
+ * @since 2022.04.0
+ */
+public @interface SpringApplicationListener {
+
+}

--- a/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/annotations/SpringFailureAnalyzer.java
+++ b/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/annotations/SpringFailureAnalyzer.java
@@ -1,0 +1,16 @@
+package com.jcohy.boot.configuration.processor.annotations;
+
+/**
+ * 描述: .
+ * <p>
+ * Copyright © 2022
+ * <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
+ * </p>
+ *
+ * @author jiac
+ * @version 2022.04.0 2022/4/20:11:10
+ * @since 2022.04.0
+ */
+public @interface SpringFailureAnalyzer {
+
+}

--- a/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/package-info.java
+++ b/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/package-info.java
@@ -1,0 +1,12 @@
+/**
+ * 描述: .
+ * <p>
+ * Copyright © 2022
+ * <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
+ * </p>
+ *
+ * @author jiac
+ * @version 2022.04.0 2022/4/20:11:07
+ * @since 2022.04.0
+ */
+package com.jcohy.boot.configuration.processor;

--- a/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/utils/Constants.java
+++ b/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/utils/Constants.java
@@ -1,0 +1,34 @@
+package com.jcohy.boot.configuration.processor.utils;
+
+/**
+ * 描述: 常量类.
+ * <p>
+ * Copyright © 2022
+ * <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
+ * </p>
+ *
+ * @author jiac
+ * @version 2022.04.0 2022/4/20:11:14
+ * @since 2022.04.0
+ */
+public final class Constants {
+
+    /**
+     * META-INF/services/.
+     */
+    public static final String SERVICE_RESOURCE_LOCATION = "META-INF/services/";
+
+    /**
+     * META-INF/spring.factories.
+     */
+    public static final String SPRING_FACTORY_RESOURCE_LOCATION = "META-INF/spring.factories";
+
+    /**
+     * META-INF/spring-devtools.properties.
+     */
+    public static final String DEVTOOLS_RESOURCE_LOCATION = "META-INF/spring-devtools.properties";
+
+    private Constants() {
+    }
+
+}

--- a/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/utils/Elements.java
+++ b/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/utils/Elements.java
@@ -1,0 +1,129 @@
+package com.jcohy.boot.configuration.processor.utils;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.SimpleElementVisitor8;
+
+/**
+ * 描述: {@link Element} 表示一个程序元素，比如包，类或者方法。每个元素都表示一个静态的语言级构造（不表示虚拟机运行时的构造）.
+ * <p>
+ * Copyright © 2022
+ * <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
+ * </p>
+ *
+ * @author jiac
+ * @version 2022.04.0 2022/4/20:11:14
+ * @since 2022.04.0
+ */
+public final class Elements {
+
+    private Elements() {
+    }
+
+    /**
+     * 获取此元素类型的完全限定名.
+     * @param element element
+     * @return /
+     * @since 2022.04.0
+     */
+    public static String getQualifiedName(Element element) {
+        if (element != null) {
+            TypeElement enclosingElement = getEnclosingTypeElement(element.asType());
+            if (enclosingElement != null) {
+                return getQualifiedName(enclosingElement) + "$"
+                        + ((DeclaredType) element.asType()).asElement().getSimpleName().toString();
+            }
+            if (element instanceof TypeElement) {
+                return ((TypeElement) element).getQualifiedName().toString();
+            }
+        }
+        return null;
+    }
+
+    private static TypeElement getEnclosingTypeElement(TypeMirror type) {
+        if (type instanceof DeclaredType) {
+            DeclaredType declaredType = (DeclaredType) type;
+            Element enclosingElement = declaredType.asElement().getEnclosingElement();
+            if (enclosingElement instanceof TypeElement) {
+                return (TypeElement) enclosingElement;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 将 Element 转为 TypeElement.
+     * @param element element
+     * @return /
+     * @since 2022.04.0
+     */
+    public static TypeElement asType(Element element) {
+        return element.accept(TypeElementVisitor.INSTANCE, null);
+    }
+
+    /**
+     * 根据 TypeElement 获取元素的全类名.
+     * @param element element
+     * @return string 全类名
+     * @since 2022.04.0
+     */
+    public static String getBinaryName(Element element) {
+        return getBinaryNameImpl(element, element.getSimpleName().toString());
+    }
+
+    /**
+     * 根据 TypeElement 获取元素的全类名.
+     * @param element element
+     * @param className 类名(不含包名)
+     * @return string 全类名
+     * @since 2022.04.0
+     */
+    public static String getBinaryNameImpl(Element element, String className) {
+        Element enclosingElement = element.getEnclosingElement();
+
+        if (enclosingElement instanceof PackageElement) {
+            PackageElement pkg = (PackageElement) enclosingElement;
+            if (pkg.isUnnamed()) {
+                return className;
+            }
+            return pkg.getQualifiedName() + "." + className;
+        }
+
+        TypeElement typeElement = (TypeElement) enclosingElement;
+        return getBinaryNameImpl(typeElement, typeElement.getSimpleName() + "$" + className);
+    }
+
+    private static final class TypeElementVisitor extends CastingElementVisitor<TypeElement> {
+
+        private static final TypeElementVisitor INSTANCE = new TypeElementVisitor();
+
+        TypeElementVisitor() {
+            super("type element");
+        }
+
+        @Override
+        public TypeElement visitType(TypeElement e, Void ignore) {
+            return e;
+        }
+
+    }
+
+    private abstract static class CastingElementVisitor<T> extends SimpleElementVisitor8<T, Void> {
+
+        private final String label;
+
+        CastingElementVisitor(String label) {
+            this.label = label;
+        }
+
+        @Override
+        protected final T defaultAction(Element e, Void ignore) {
+            throw new IllegalArgumentException(e + " does not represent a " + this.label);
+        }
+
+    }
+
+}

--- a/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/utils/MultiMapSet.java
+++ b/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/utils/MultiMapSet.java
@@ -1,0 +1,129 @@
+package com.jcohy.boot.configuration.processor.utils;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * 描述: 一键多值 Map.
+ * <p>
+ * Copyright © 2022
+ * <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
+ * </p>
+ *
+ * @param <K> key
+ * @param <V> value
+ * @author jiac
+ * @version 2022.04.0 2022/4/20:11:33
+ * @since 2022.04.0
+ */
+public class MultiMapSet<K, V> {
+
+    private final transient Map<K, Set<V>> map;
+
+    public MultiMapSet() {
+        this.map = new HashMap<>();
+    }
+
+    public Set<V> createSet() {
+        return new HashSet<>();
+    }
+
+    /**
+     * put to MultiMapSet.
+     * @param key 键
+     * @param value 值
+     * @return boolean
+     */
+    public boolean put(K key, V value) {
+        Set<V> set = this.map.get(key);
+        if (set == null) {
+            set = createSet();
+            if (set.add(value)) {
+                this.map.put(key, set);
+                return true;
+            }
+            else {
+                throw new AssertionError("New set violated the set spec");
+            }
+        }
+        else {
+            return set.add(value);
+        }
+    }
+
+    /**
+     * 是否包含某个 key.
+     * @param key key
+     * @return 结果
+     */
+    public boolean containsKey(K key) {
+        return this.map.containsKey(key);
+    }
+
+    /**
+     * 是否包含 value 中的某个值.
+     * @param value value
+     * @return 是否包含
+     */
+    public boolean containsVal(V value) {
+        Collection<Set<V>> values = this.map.values();
+        return values.stream().anyMatch((vs) -> vs.contains(value));
+    }
+
+    /**
+     * key 集合.
+     * @return keys
+     */
+    public Set<K> keySet() {
+        return this.map.keySet();
+    }
+
+    /**
+     * put list to MultiSetMap.
+     * @param key 键
+     * @param set 值列表
+     * @return boolean
+     */
+    public boolean putAll(K key, Set<V> set) {
+        if (set == null) {
+            return false;
+        }
+        else {
+            this.map.put(key, set);
+            return true;
+        }
+    }
+
+    /**
+     * get List by key.
+     * @param key 键
+     * @return 返回一个 List
+     */
+    public Set<V> get(K key) {
+        return this.map.get(key);
+    }
+
+    /**
+     * clear MultiSetMap.
+     */
+    public void clear() {
+        this.map.clear();
+    }
+
+    /**
+     * isEmpty.
+     * @return isEmpty
+     */
+    public boolean isEmpty() {
+        return this.map.isEmpty();
+    }
+
+    @Override
+    public String toString() {
+        return "MultiMapSet{" + "map=" + this.map + '}';
+    }
+
+}

--- a/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/utils/Types.java
+++ b/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/utils/Types.java
@@ -1,0 +1,114 @@
+package com.jcohy.boot.configuration.processor.utils;
+
+import java.util.List;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.ErrorType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeVariable;
+import javax.lang.model.util.SimpleTypeVisitor8;
+
+/**
+ * 描述: Java 类型工具类.
+ * <p>
+ * Copyright © 2022
+ * <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
+ * </p>
+ *
+ * @author jiac
+ * @version 2022.04.0 2022/4/20:11:36
+ * @since 2022.04.0
+ */
+public class Types {
+
+    protected Types() {
+    }
+
+    public static DeclaredType asDeclared(TypeMirror maybeDeclaredType) {
+        return maybeDeclaredType.accept(DeclaredTypeVisitor.INSTANCE, null);
+    }
+
+    public static String getBinaryName(TypeMirror mirror) {
+        return Elements.getBinaryName(asElement(mirror));
+    }
+
+    /**
+     * 检查父接口是否包含注解.
+     * @param interfaces 父接口列表
+     * @param annotationClassName 注解名
+     * @return boolean
+     */
+    public static boolean contain(List<? extends TypeMirror> interfaces, String annotationClassName) {
+        for (TypeMirror typeMirror : interfaces) {
+            return Types.getBinaryName(typeMirror).equals(annotationClassName);
+        }
+        return false;
+    }
+
+    public static TypeElement asTypeElement(TypeMirror mirror) {
+        return Elements.asType(asElement(mirror));
+    }
+
+    public static Element asElement(TypeMirror typeMirror) {
+        return typeMirror.accept(AsElementVisitor.INSTANCE, null);
+    }
+
+    private static final class DeclaredTypeVisitor extends CastingTypeVisitor<DeclaredType> {
+
+        private static final DeclaredTypeVisitor INSTANCE = new DeclaredTypeVisitor();
+
+        DeclaredTypeVisitor() {
+            super("declared type");
+        }
+
+        @Override
+        public DeclaredType visitDeclared(DeclaredType type, Void ignore) {
+            return type;
+        }
+
+    }
+
+    private static final class AsElementVisitor extends SimpleTypeVisitor8<Element, Void> {
+
+        private static final AsElementVisitor INSTANCE = new AsElementVisitor();
+
+        @Override
+        protected Element defaultAction(TypeMirror e, Void p) {
+            throw new IllegalArgumentException(e + " cannot be converted to an Element");
+        }
+
+        @Override
+        public Element visitDeclared(DeclaredType t, Void p) {
+            return t.asElement();
+        }
+
+        @Override
+        public Element visitError(ErrorType t, Void p) {
+            return t.asElement();
+        }
+
+        @Override
+        public Element visitTypeVariable(TypeVariable t, Void p) {
+            return t.asElement();
+        }
+
+    }
+
+    private abstract static class CastingTypeVisitor<T> extends SimpleTypeVisitor8<T, Void> {
+
+        private final String label;
+
+        CastingTypeVisitor(String label) {
+            this.label = label;
+        }
+
+        @Override
+        protected T defaultAction(TypeMirror e, Void v) {
+            throw new IllegalArgumentException(e + " does not represent a " + this.label);
+        }
+
+    }
+
+}

--- a/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/value/AbstractValueExtractor.java
+++ b/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/value/AbstractValueExtractor.java
@@ -1,0 +1,51 @@
+package com.jcohy.boot.configuration.processor.value;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.type.DeclaredType;
+
+import com.jcohy.boot.configuration.processor.utils.Elements;
+
+/**
+ * 描述: .
+ * <p>
+ * Copyright © 2022
+ * <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
+ * </p>
+ *
+ * @author jiac
+ * @version 2022.04.0 2022/4/20:12:05
+ * @since 2022.04.0
+ */
+public abstract class AbstractValueExtractor implements ValueExtractor {
+
+    /**
+     * 提取值.
+     * @param annotationValue 表示注解类型元素的值。
+     * @return /
+     */
+    @SuppressWarnings("unchecked")
+    protected Stream<Object> extractValues(AnnotationValue annotationValue) {
+        if (annotationValue == null) {
+            return Stream.empty();
+        }
+
+        Object value = annotationValue.getValue();
+
+        if (value instanceof List) {
+            return ((List<AnnotationValue>) value).stream().map((annotation) -> extractValue(annotation.getValue()));
+        }
+
+        return Stream.of(value);
+    }
+
+    private Object extractValue(Object value) {
+        if (value instanceof DeclaredType) {
+            return Elements.getQualifiedName(((DeclaredType) value).asElement());
+        }
+        return value;
+    }
+
+}

--- a/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/value/NamedValuesExtractor.java
+++ b/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/value/NamedValuesExtractor.java
@@ -1,0 +1,45 @@
+package com.jcohy.boot.configuration.processor.value;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.ExecutableElement;
+
+/**
+ * 描述: .
+ * <p>
+ * Copyright © 2022
+ * <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
+ * </p>
+ *
+ * @author jiac
+ * @version 2022.04.0 2022/4/20:12:05
+ * @since 2022.04.0
+ */
+public class NamedValuesExtractor extends AbstractValueExtractor {
+
+    private final Set<String> names;
+
+    NamedValuesExtractor(String... names) {
+        this.names = new HashSet<>(Arrays.asList(names));
+    }
+
+    @Override
+    public List<Object> getValues(AnnotationMirror annotation) {
+        List<Object> result = new ArrayList<>();
+        Map<? extends ExecutableElement, ? extends AnnotationValue> elementValues = annotation.getElementValues();
+        annotation.getElementValues().forEach((key, value) -> {
+            if (this.names.contains(key.getSimpleName().toString())) {
+                extractValues(value).forEach(result::add);
+            }
+        });
+        return result;
+    }
+
+}

--- a/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/value/ValueExtractor.java
+++ b/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/java/com/jcohy/boot/configuration/processor/value/ValueExtractor.java
@@ -1,0 +1,37 @@
+package com.jcohy.boot.configuration.processor.value;
+
+import java.util.List;
+
+import javax.lang.model.element.AnnotationMirror;
+
+/**
+ * 描述: 属性提取器.
+ * <p>
+ * Copyright © 2022
+ * <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
+ * </p>
+ *
+ * @author jiac
+ * @version 2022.04.0 2022/4/20:12:04
+ * @since 2022.04.0
+ */
+@FunctionalInterface
+public interface ValueExtractor {
+
+    /**
+     * 指定注解的属性列表，后续会从此属性中提取值.
+     * @param names 属性列表
+     * @return valueExtractor
+     */
+    static ValueExtractor allFrom(String... names) {
+        return new NamedValuesExtractor(names);
+    }
+
+    /**
+     * 获取注解的值.
+     * @param annotation 注解
+     * @return 值
+     */
+    List<Object> getValues(AnnotationMirror annotation);
+
+}

--- a/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/resources/META-INF/gradle/incremental.annotation.processors
+++ b/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/resources/META-INF/gradle/incremental.annotation.processors
@@ -1,0 +1,2 @@
+JavaSpiServiceProcessor,AGGREGATING
+SpringFactoriesProcessor,ISOLATING

--- a/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/jcohy-boot-projects/jcohy-boot-configuration-processor/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,2 @@
+com.jcohy.boot.configuration.processor.JavaSpiServiceProcessor
+com.jcohy.boot.configuration.processor.SpringFactoriesProcessor

--- a/jcohy-boot-projects/jcohy-boot-configuration-processor/src/test/java/com/jcohy/boot/configuration/processor/JavaSpiServiceProcessorTest.java
+++ b/jcohy-boot-projects/jcohy-boot-configuration-processor/src/test/java/com/jcohy/boot/configuration/processor/JavaSpiServiceProcessorTest.java
@@ -1,0 +1,61 @@
+package com.jcohy.boot.configuration.processor;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Properties;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.jcohy.boot.configuration.processor.spi.StartupServiceTestOne;
+import com.jcohy.boot.configuration.processor.spi.StartupServiceTestTwo;
+import com.jcohy.boot.configuration.processor.spi.TestJavaSpiServiceProcessor;
+import com.jcohy.boot.test.TestCompiler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 描述: .
+ * <p>
+ * Copyright © 2022
+ * <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
+ * </p>
+ *
+ * @author jiac
+ * @version 2022.04.0 2022/4/22:19:54
+ * @since 2022.04.0
+ */
+public class JavaSpiServiceProcessorTest {
+
+    @TempDir
+    File tempDir;
+
+    private TestCompiler compiler;
+
+    @BeforeEach
+    void createCompiler() throws IOException {
+        this.compiler = new TestCompiler(new File("src/test/resources"));
+    }
+
+    @Test
+    void annotatedClass() throws IOException {
+        Properties properties = compile(StartupServiceTestOne.class, StartupServiceTestTwo.class);
+        assertThat(properties).hasSize(2);
+    }
+
+    // private WebTestClient.ListBodySpec<Object> assertThat(Properties properties) {
+    // return null;
+    // }
+
+    private Properties compile(Class<?>... types) throws IOException {
+        return process(types).getWrittenProperties();
+    }
+
+    private TestJavaSpiServiceProcessor process(Class<?>... types) {
+        TestJavaSpiServiceProcessor processor = new TestJavaSpiServiceProcessor(this.compiler.getOutputLocation());
+        this.compiler.getTask(types).call(processor);
+        return processor;
+    }
+
+}

--- a/jcohy-boot-projects/jcohy-boot-configuration-processor/src/test/java/com/jcohy/boot/configuration/processor/SpringFactoryProcessorTest.java
+++ b/jcohy-boot-projects/jcohy-boot-configuration-processor/src/test/java/com/jcohy/boot/configuration/processor/SpringFactoryProcessorTest.java
@@ -1,0 +1,90 @@
+package com.jcohy.boot.configuration.processor;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import org.springframework.util.StringUtils;
+
+import com.jcohy.boot.configuration.processor.spring.TestNoApplicationListener;
+import com.jcohy.boot.configuration.processor.spring.TestSpringApplicationContextInitializer;
+import com.jcohy.boot.configuration.processor.spring.TestSpringApplicationListener;
+import com.jcohy.boot.configuration.processor.spring.TestSpringFactoryProcessor;
+import com.jcohy.boot.test.TestCompiler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 描述: .
+ * <p>
+ * Copyright © 2022
+ * <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
+ * </p>
+ *
+ * @author jiac
+ * @version 2022.04.0 2022/4/24:11:36
+ * @since 2022.04.0
+ */
+public class SpringFactoryProcessorTest {
+
+    @TempDir
+    File tempDir;
+
+    private TestCompiler compiler;
+
+    private static Map<String, List<String>> loadSpringFactories(Properties properties) {
+        Map<String, List<String>> result = new HashMap<>();
+
+        if (properties == null) {
+            return result;
+        }
+
+        for (Map.Entry<?, ?> entry : properties.entrySet()) {
+            String factoryTypeName = ((String) entry.getKey()).trim();
+            String[] factoryImplementationNames = StringUtils
+                    .commaDelimitedListToStringArray((String) entry.getValue());
+            for (String factoryImplementationName : factoryImplementationNames) {
+                result.computeIfAbsent(factoryTypeName, (key) -> new ArrayList<>())
+                        .add(factoryImplementationName.trim());
+            }
+        }
+        return result;
+    }
+
+    @BeforeEach
+    void createCompiler() throws IOException {
+        this.compiler = new TestCompiler(new File("src/test/resources"));
+    }
+
+    /**
+     * 预期结果：没有实现ApplicationListener接口的类不写入到spring.factories中.
+     * TestSagaApplicationListener.class,TestSagaApplicationContextInitializer.class,
+     * @throws IOException
+     */
+    @Test
+    void annotatedClass() throws IOException {
+        Properties properties = compile(TestSpringApplicationListener.class,
+                TestSpringApplicationContextInitializer.class, TestNoApplicationListener.class);
+        Map<String, List<String>> stringListMap = loadSpringFactories(properties);
+        assertThat(stringListMap).hasSize(2);
+    }
+
+    private Properties compile(Class<?>... types) throws IOException {
+        return process(types).getWrittenProperties();
+    }
+
+    private TestSpringFactoryProcessor process(Class<?>... types) {
+        TestSpringFactoryProcessor processor = new TestSpringFactoryProcessor(this.compiler.getOutputLocation());
+        this.compiler.getTask(types).call(processor);
+        return processor;
+    }
+
+}

--- a/jcohy-boot-projects/jcohy-boot-configuration-processor/src/test/java/com/jcohy/boot/configuration/processor/spi/StartupService.java
+++ b/jcohy-boot-projects/jcohy-boot-configuration-processor/src/test/java/com/jcohy/boot/configuration/processor/spi/StartupService.java
@@ -1,0 +1,21 @@
+package com.jcohy.boot.configuration.processor.spi;
+
+/**
+ * 描述: .
+ * <p>
+ * Copyright © 2022
+ * <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
+ * </p>
+ *
+ * @author jiac
+ * @version 2022.04.0 2022/4/22:20:04
+ * @since 2022.04.0
+ */
+public interface StartupService {
+
+    /**
+     * 启动时加载 spi.
+     */
+    void startup();
+
+}

--- a/jcohy-boot-projects/jcohy-boot-configuration-processor/src/test/java/com/jcohy/boot/configuration/processor/spi/StartupServiceTestOne.java
+++ b/jcohy-boot-projects/jcohy-boot-configuration-processor/src/test/java/com/jcohy/boot/configuration/processor/spi/StartupServiceTestOne.java
@@ -1,0 +1,24 @@
+package com.jcohy.boot.configuration.processor.spi;
+
+import com.jcohy.boot.configuration.processor.annotations.JavaSpiService;
+
+/**
+ * 描述: .
+ * <p>
+ * Copyright © 2022
+ * <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
+ * </p>
+ *
+ * @author jiac
+ * @version 2022.04.0 2022/4/22:20:05
+ * @since 2022.04.0
+ */
+@JavaSpiService(value = StartupService.class, name = "StartupServiceTestOne")
+public class StartupServiceTestOne implements StartupService {
+
+    @Override
+    public void startup() {
+
+    }
+
+}

--- a/jcohy-boot-projects/jcohy-boot-configuration-processor/src/test/java/com/jcohy/boot/configuration/processor/spi/StartupServiceTestTwo.java
+++ b/jcohy-boot-projects/jcohy-boot-configuration-processor/src/test/java/com/jcohy/boot/configuration/processor/spi/StartupServiceTestTwo.java
@@ -1,0 +1,24 @@
+package com.jcohy.boot.configuration.processor.spi;
+
+import com.jcohy.boot.configuration.processor.annotations.JavaSpiService;
+
+/**
+ * 描述: .
+ * <p>
+ * Copyright © 2022
+ * <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
+ * </p>
+ *
+ * @author jiac
+ * @version 2022.04.0 2022/4/22:20:06
+ * @since 2022.04.0
+ */
+@JavaSpiService(value = StartupService.class, name = "StartupServiceTestTwo")
+public class StartupServiceTestTwo implements StartupService {
+
+    @Override
+    public void startup() {
+
+    }
+
+}

--- a/jcohy-boot-projects/jcohy-boot-configuration-processor/src/test/java/com/jcohy/boot/configuration/processor/spi/TestJavaSpiServiceProcessor.java
+++ b/jcohy-boot-projects/jcohy-boot-configuration-processor/src/test/java/com/jcohy/boot/configuration/processor/spi/TestJavaSpiServiceProcessor.java
@@ -1,0 +1,50 @@
+package com.jcohy.boot.configuration.processor.spi;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Properties;
+
+import javax.annotation.processing.SupportedAnnotationTypes;
+
+import com.jcohy.boot.configuration.processor.JavaSpiServiceProcessor;
+import com.jcohy.boot.configuration.processor.utils.Constants;
+
+/**
+ * 描述: .
+ * <p>
+ * Copyright © 2022
+ * <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
+ * </p>
+ *
+ * @author jiac
+ * @version 2022.04.0 2022/4/22:20:06
+ * @since 2022.04.0
+ */
+@SupportedAnnotationTypes({ "com.jcohy.boot.configuration.processor.annotations.JavaSpiService" })
+public class TestJavaSpiServiceProcessor extends JavaSpiServiceProcessor {
+
+    private final File outputLocation;
+
+    public TestJavaSpiServiceProcessor(File outputLocation) {
+        this.outputLocation = outputLocation;
+    }
+
+    public Properties getWrittenProperties() throws IOException {
+        File file = getWrittenFile();
+        if (!file.exists()) {
+            return null;
+        }
+        try (FileInputStream inputStream = new FileInputStream(file)) {
+            Properties properties = new Properties();
+            properties.load(inputStream);
+            return properties;
+        }
+    }
+
+    public File getWrittenFile() {
+        return new File(this.outputLocation, Constants.SERVICE_RESOURCE_LOCATION + File.separator
+                + "com.jcohy.boot.configuration.processor.spi.StartupService");
+    }
+
+}

--- a/jcohy-boot-projects/jcohy-boot-configuration-processor/src/test/java/com/jcohy/boot/configuration/processor/spring/TestNoApplicationListener.java
+++ b/jcohy-boot-projects/jcohy-boot-configuration-processor/src/test/java/com/jcohy/boot/configuration/processor/spring/TestNoApplicationListener.java
@@ -1,0 +1,19 @@
+package com.jcohy.boot.configuration.processor.spring;
+
+import com.jcohy.boot.configuration.processor.annotations.SpringApplicationListener;
+
+/**
+ * 描述: .
+ * <p>
+ * Copyright © 2022
+ * <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
+ * </p>
+ *
+ * @author jiac
+ * @version 2022.04.0 2022/4/24:11:32
+ * @since 2022.04.0
+ */
+@SpringApplicationListener
+public class TestNoApplicationListener {
+
+}

--- a/jcohy-boot-projects/jcohy-boot-configuration-processor/src/test/java/com/jcohy/boot/configuration/processor/spring/TestSpringApplicationContextInitializer.java
+++ b/jcohy-boot-projects/jcohy-boot-configuration-processor/src/test/java/com/jcohy/boot/configuration/processor/spring/TestSpringApplicationContextInitializer.java
@@ -1,0 +1,29 @@
+package com.jcohy.boot.configuration.processor.spring;
+
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import com.jcohy.boot.configuration.processor.annotations.JavaSpiService;
+import com.jcohy.boot.configuration.processor.annotations.SpringApplicationContextInitializer;
+
+/**
+ * 描述: .
+ * <p>
+ * Copyright © 2022
+ * <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
+ * </p>
+ *
+ * @author jiac
+ * @version 2022.04.0 2022/4/24:11:32
+ * @since 2022.04.0
+ */
+@SpringApplicationContextInitializer
+@JavaSpiService(TestSpringApplicationContextInitializer.class)
+public class TestSpringApplicationContextInitializer implements ApplicationContextInitializer {
+
+    @Override
+    public void initialize(ConfigurableApplicationContext applicationContext) {
+        System.out.println("ApplicationContextInitializer......");
+    }
+
+}

--- a/jcohy-boot-projects/jcohy-boot-configuration-processor/src/test/java/com/jcohy/boot/configuration/processor/spring/TestSpringApplicationListener.java
+++ b/jcohy-boot-projects/jcohy-boot-configuration-processor/src/test/java/com/jcohy/boot/configuration/processor/spring/TestSpringApplicationListener.java
@@ -1,0 +1,27 @@
+package com.jcohy.boot.configuration.processor.spring;
+
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationListener;
+
+import com.jcohy.boot.configuration.processor.annotations.SpringApplicationListener;
+
+/**
+ * 描述: .
+ * <p>
+ * Copyright © 2022
+ * <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
+ * </p>
+ *
+ * @author jiac
+ * @version 2022.04.0 2022/4/24:11:33
+ * @since 2022.04.0
+ */
+@SpringApplicationListener
+public class TestSpringApplicationListener implements ApplicationListener {
+
+    @Override
+    public void onApplicationEvent(ApplicationEvent event) {
+        System.out.println("ApplicationEvent......");
+    }
+
+}

--- a/jcohy-boot-projects/jcohy-boot-configuration-processor/src/test/java/com/jcohy/boot/configuration/processor/spring/TestSpringComponent.java
+++ b/jcohy-boot-projects/jcohy-boot-configuration-processor/src/test/java/com/jcohy/boot/configuration/processor/spring/TestSpringComponent.java
@@ -1,0 +1,19 @@
+package com.jcohy.boot.configuration.processor.spring;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * 描述: .
+ * <p>
+ * Copyright © 2022
+ * <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
+ * </p>
+ *
+ * @author jiac
+ * @version 2022.04.0 2022/4/24:11:34
+ * @since 2022.04.0
+ */
+@Component
+public interface TestSpringComponent {
+
+}

--- a/jcohy-boot-projects/jcohy-boot-configuration-processor/src/test/java/com/jcohy/boot/configuration/processor/spring/TestSpringConfiguration.java
+++ b/jcohy-boot-projects/jcohy-boot-configuration-processor/src/test/java/com/jcohy/boot/configuration/processor/spring/TestSpringConfiguration.java
@@ -1,0 +1,19 @@
+package com.jcohy.boot.configuration.processor.spring;
+
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 描述: .
+ * <p>
+ * Copyright © 2022
+ * <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
+ * </p>
+ *
+ * @author jiac
+ * @version 2022.04.0 2022/4/24:11:35
+ * @since 2022.04.0
+ */
+@Configuration
+public class TestSpringConfiguration {
+
+}

--- a/jcohy-boot-projects/jcohy-boot-configuration-processor/src/test/java/com/jcohy/boot/configuration/processor/spring/TestSpringFactoryProcessor.java
+++ b/jcohy-boot-projects/jcohy-boot-configuration-processor/src/test/java/com/jcohy/boot/configuration/processor/spring/TestSpringFactoryProcessor.java
@@ -1,0 +1,49 @@
+package com.jcohy.boot.configuration.processor.spring;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Properties;
+
+import javax.annotation.processing.SupportedAnnotationTypes;
+
+import com.jcohy.boot.configuration.processor.SpringFactoriesProcessor;
+import com.jcohy.boot.configuration.processor.utils.Constants;
+
+/**
+ * 描述: .
+ * <p>
+ * Copyright © 2022
+ * <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
+ * </p>
+ *
+ * @author jiac
+ * @version 2022.04.0 2022/4/24:11:36
+ * @since 2022.04.0
+ */
+@SupportedAnnotationTypes({ "*" })
+public class TestSpringFactoryProcessor extends SpringFactoriesProcessor {
+
+    private final File outputLocation;
+
+    public TestSpringFactoryProcessor(File outputLocation) {
+        this.outputLocation = outputLocation;
+    }
+
+    public Properties getWrittenProperties() throws IOException {
+        File file = getWrittenFile();
+        if (!file.exists()) {
+            return null;
+        }
+        try (FileInputStream inputStream = new FileInputStream(file)) {
+            Properties properties = new Properties();
+            properties.load(inputStream);
+            return properties;
+        }
+    }
+
+    public File getWrittenFile() {
+        return new File(this.outputLocation, Constants.SPRING_FACTORY_RESOURCE_LOCATION);
+    }
+
+}

--- a/jcohy-boot-projects/jcohy-boot-configuration-processor/src/test/java/com/jcohy/boot/configuration/processor/spring/TestSpringFailureAnalyzer.java
+++ b/jcohy-boot-projects/jcohy-boot-configuration-processor/src/test/java/com/jcohy/boot/configuration/processor/spring/TestSpringFailureAnalyzer.java
@@ -1,0 +1,25 @@
+package com.jcohy.boot.configuration.processor.spring;
+
+import org.springframework.boot.diagnostics.FailureAnalysis;
+import org.springframework.boot.diagnostics.FailureAnalyzer;
+
+/**
+ * 描述: .
+ * <p>
+ * Copyright © 2022
+ * <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
+ * </p>
+ *
+ * @author jiac
+ * @version 2022.04.0 2022/4/24:11:35
+ * @since 2022.04.0
+ */
+public class TestSpringFailureAnalyzer implements FailureAnalyzer {
+
+    @Override
+    public FailureAnalysis analyze(Throwable failure) {
+        System.out.println("FailureAnalysis......");
+        return null;
+    }
+
+}

--- a/jcohy-boot-test/build.gradle
+++ b/jcohy-boot-test/build.gradle
@@ -5,6 +5,4 @@ plugins {
 description = "Jcohy Boot Annotation Processor Generation spring.factories and Java SPI file"
 
 dependencies {
-
-	testImplementation(project(":jcohy-boot-test"))
 }

--- a/jcohy-boot-test/src/main/java/com/jcohy/boot/test/TestCompiler.java
+++ b/jcohy-boot-test/src/main/java/com/jcohy/boot/test/TestCompiler.java
@@ -17,95 +17,98 @@ import javax.tools.ToolProvider;
 /**
  * 描述: 包装 {@link JavaCompiler} ,在测试中更易使用.
  * <p>
- *     Copyright © 2022 <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
+ * Copyright © 2022
+ * <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
  * </p>
+ *
  * @author jiac
  * @version 2022.04.0 2022/4/22:19:44
  * @since 2022.04.0
  */
 public class TestCompiler {
-	/**
-	 * The default source directory.
-	 */
-	public static final File SOURCE_DIRECTORY = new File("src/test/java");
 
-	private final JavaCompiler compiler;
+    /**
+     * The default source directory.
+     */
+    public static final File SOURCE_DIRECTORY = new File("src/test/java");
 
-	private final StandardJavaFileManager fileManager;
+    private final JavaCompiler compiler;
 
-	private final File outputLocation;
+    private final StandardJavaFileManager fileManager;
 
-	public TestCompiler(File outputLocation) throws IOException {
-		this(ToolProvider.getSystemJavaCompiler(), outputLocation);
-	}
+    private final File outputLocation;
 
-	public TestCompiler(JavaCompiler compiler, File outputLocation) throws IOException {
-		this.compiler = compiler;
-		this.fileManager = compiler.getStandardFileManager(null, null, null);
-		this.outputLocation = outputLocation;
-		this.outputLocation.mkdirs();
-		Iterable<? extends File> temp = Collections.singletonList(this.outputLocation);
-		this.fileManager.setLocation(StandardLocation.CLASS_OUTPUT, temp);
-		this.fileManager.setLocation(StandardLocation.SOURCE_OUTPUT, temp);
-	}
+    public TestCompiler(File outputLocation) throws IOException {
+        this(ToolProvider.getSystemJavaCompiler(), outputLocation);
+    }
 
-	public static String sourcePathFor(Class<?> type) {
-		return type.getName().replace('.', '/') + ".java";
-	}
+    public TestCompiler(JavaCompiler compiler, File outputLocation) throws IOException {
+        this.compiler = compiler;
+        this.fileManager = compiler.getStandardFileManager(null, null, null);
+        this.outputLocation = outputLocation;
+        this.outputLocation.mkdirs();
+        Iterable<? extends File> temp = Collections.singletonList(this.outputLocation);
+        this.fileManager.setLocation(StandardLocation.CLASS_OUTPUT, temp);
+        this.fileManager.setLocation(StandardLocation.SOURCE_OUTPUT, temp);
+    }
 
-	public TestCompilationTask getTask(Collection<File> sourceFiles) {
-		Iterable<? extends JavaFileObject> javaFileObjects = this.fileManager.getJavaFileObjectsFromFiles(sourceFiles);
-		return getTask(javaFileObjects);
-	}
+    public static String sourcePathFor(Class<?> type) {
+        return type.getName().replace('.', '/') + ".java";
+    }
 
-	public TestCompilationTask getTask(Class<?>... types) {
-		Iterable<? extends JavaFileObject> javaFileObjects = getJavaFileObjects(types);
-		return getTask(javaFileObjects);
-	}
+    public TestCompilationTask getTask(Collection<File> sourceFiles) {
+        Iterable<? extends JavaFileObject> javaFileObjects = this.fileManager.getJavaFileObjectsFromFiles(sourceFiles);
+        return getTask(javaFileObjects);
+    }
 
-	private TestCompilationTask getTask(Iterable<? extends JavaFileObject> javaFileObjects) {
-		return new TestCompilationTask(
-				this.compiler.getTask(null, this.fileManager, null, null, null, javaFileObjects));
-	}
+    public TestCompilationTask getTask(Class<?>... types) {
+        Iterable<? extends JavaFileObject> javaFileObjects = getJavaFileObjects(types);
+        return getTask(javaFileObjects);
+    }
 
-	public File getOutputLocation() {
-		return this.outputLocation;
-	}
+    private TestCompilationTask getTask(Iterable<? extends JavaFileObject> javaFileObjects) {
+        return new TestCompilationTask(
+                this.compiler.getTask(null, this.fileManager, null, null, null, javaFileObjects));
+    }
 
-	private Iterable<? extends JavaFileObject> getJavaFileObjects(Class<?>... types) {
-		File[] files = new File[types.length];
-		for (int i = 0; i < types.length; i++) {
-			files[i] = getFile(types[i]);
-		}
-		return this.fileManager.getJavaFileObjects(files);
-	}
+    public File getOutputLocation() {
+        return this.outputLocation;
+    }
 
-	protected File getFile(Class<?> type) {
-		return new File(getSourceDirectory(), sourcePathFor(type));
-	}
+    private Iterable<? extends JavaFileObject> getJavaFileObjects(Class<?>... types) {
+        File[] files = new File[types.length];
+        for (int i = 0; i < types.length; i++) {
+            files[i] = getFile(types[i]);
+        }
+        return this.fileManager.getJavaFileObjects(files);
+    }
 
-	protected File getSourceDirectory() {
-		return SOURCE_DIRECTORY;
-	}
+    protected File getFile(Class<?> type) {
+        return new File(getSourceDirectory(), sourcePathFor(type));
+    }
 
-	/**
-	 * A compilation task.
-	 */
-	public static class TestCompilationTask {
+    protected File getSourceDirectory() {
+        return SOURCE_DIRECTORY;
+    }
 
-		private final CompilationTask task;
+    /**
+     * A compilation task.
+     */
+    public static class TestCompilationTask {
 
-		public TestCompilationTask(CompilationTask task) {
-			this.task = task;
-		}
+        private final CompilationTask task;
 
-		public void call(Processor... processors) {
-			this.task.setProcessors(Arrays.asList(processors));
-			if (!this.task.call()) {
-				throw new IllegalStateException("Compilation failed");
-			}
-		}
+        public TestCompilationTask(CompilationTask task) {
+            this.task = task;
+        }
 
-	}
+        public void call(Processor... processors) {
+            this.task.setProcessors(Arrays.asList(processors));
+            if (!this.task.call()) {
+                throw new IllegalStateException("Compilation failed");
+            }
+        }
+
+    }
 
 }

--- a/jcohy-boot-test/src/main/java/com/jcohy/boot/test/TestCompiler.java
+++ b/jcohy-boot-test/src/main/java/com/jcohy/boot/test/TestCompiler.java
@@ -1,0 +1,111 @@
+package com.jcohy.boot.test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import javax.annotation.processing.Processor;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaCompiler.CompilationTask;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.StandardLocation;
+import javax.tools.ToolProvider;
+
+/**
+ * 描述: 包装 {@link JavaCompiler} ,在测试中更易使用.
+ * <p>
+ *     Copyright © 2022 <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
+ * </p>
+ * @author jiac
+ * @version 2022.04.0 2022/4/22:19:44
+ * @since 2022.04.0
+ */
+public class TestCompiler {
+	/**
+	 * The default source directory.
+	 */
+	public static final File SOURCE_DIRECTORY = new File("src/test/java");
+
+	private final JavaCompiler compiler;
+
+	private final StandardJavaFileManager fileManager;
+
+	private final File outputLocation;
+
+	public TestCompiler(File outputLocation) throws IOException {
+		this(ToolProvider.getSystemJavaCompiler(), outputLocation);
+	}
+
+	public TestCompiler(JavaCompiler compiler, File outputLocation) throws IOException {
+		this.compiler = compiler;
+		this.fileManager = compiler.getStandardFileManager(null, null, null);
+		this.outputLocation = outputLocation;
+		this.outputLocation.mkdirs();
+		Iterable<? extends File> temp = Collections.singletonList(this.outputLocation);
+		this.fileManager.setLocation(StandardLocation.CLASS_OUTPUT, temp);
+		this.fileManager.setLocation(StandardLocation.SOURCE_OUTPUT, temp);
+	}
+
+	public static String sourcePathFor(Class<?> type) {
+		return type.getName().replace('.', '/') + ".java";
+	}
+
+	public TestCompilationTask getTask(Collection<File> sourceFiles) {
+		Iterable<? extends JavaFileObject> javaFileObjects = this.fileManager.getJavaFileObjectsFromFiles(sourceFiles);
+		return getTask(javaFileObjects);
+	}
+
+	public TestCompilationTask getTask(Class<?>... types) {
+		Iterable<? extends JavaFileObject> javaFileObjects = getJavaFileObjects(types);
+		return getTask(javaFileObjects);
+	}
+
+	private TestCompilationTask getTask(Iterable<? extends JavaFileObject> javaFileObjects) {
+		return new TestCompilationTask(
+				this.compiler.getTask(null, this.fileManager, null, null, null, javaFileObjects));
+	}
+
+	public File getOutputLocation() {
+		return this.outputLocation;
+	}
+
+	private Iterable<? extends JavaFileObject> getJavaFileObjects(Class<?>... types) {
+		File[] files = new File[types.length];
+		for (int i = 0; i < types.length; i++) {
+			files[i] = getFile(types[i]);
+		}
+		return this.fileManager.getJavaFileObjects(files);
+	}
+
+	protected File getFile(Class<?> type) {
+		return new File(getSourceDirectory(), sourcePathFor(type));
+	}
+
+	protected File getSourceDirectory() {
+		return SOURCE_DIRECTORY;
+	}
+
+	/**
+	 * A compilation task.
+	 */
+	public static class TestCompilationTask {
+
+		private final CompilationTask task;
+
+		public TestCompilationTask(CompilationTask task) {
+			this.task = task;
+		}
+
+		public void call(Processor... processors) {
+			this.task.setProcessors(Arrays.asList(processors));
+			if (!this.task.call()) {
+				throw new IllegalStateException("Compilation failed");
+			}
+		}
+
+	}
+
+}

--- a/jcohy-boot-test/src/main/java/com/jcohy/boot/test/package-info.java
+++ b/jcohy-boot-test/src/main/java/com/jcohy/boot/test/package-info.java
@@ -1,11 +1,11 @@
 /**
  * 描述: .
  * <p>
- *     Copyright © 2022 <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
+ * Copyright © 2022
+ * <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
  * </p>
  * @author jiac
  * @version 2022.04.0 2022/4/22:19:42
  * @since 2022.04.0
  */
 package com.jcohy.boot.test;
-

--- a/jcohy-boot-test/src/main/java/com/jcohy/boot/test/package-info.java
+++ b/jcohy-boot-test/src/main/java/com/jcohy/boot/test/package-info.java
@@ -1,0 +1,11 @@
+/**
+ * 描述: .
+ * <p>
+ *     Copyright © 2022 <a href="https://www.jcohy.com" target= "_blank">https://www.jcohy.com</a>
+ * </p>
+ * @author jiac
+ * @version 2022.04.0 2022/4/22:19:42
+ * @since 2022.04.0
+ */
+package com.jcohy.boot.test;
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,3 +4,5 @@ include 'jcohy-boot-docs'
 
 include 'jcohy-boot-projects:jcohy-boot-configuration-processor'
 include 'jcohy-boot-projects:jcohy-boot-dependencies'
+
+include 'jcohy-boot-test'

--- a/src/checkstyle/checkstyle-header.txt
+++ b/src/checkstyle/checkstyle-header.txt
@@ -1,0 +1,17 @@
+^\Q/*\E$
+^\Q * Copyright \E2012-20\d\d\Q the original author or authors.\E$
+^\Q *\E$
+^\Q * Licensed under the Apache License, Version 2.0 (the "License");\E$
+^\Q * you may not use this file except in compliance with the License.\E$
+^\Q * You may obtain a copy of the License at\E$
+^\Q *\E$
+^\Q *      https://www.apache.org/licenses/LICENSE-2.0\E$
+^\Q *\E$
+^\Q * Unless required by applicable law or agreed to in writing, software\E$
+^\Q * distributed under the License is distributed on an "AS IS" BASIS,\E$
+^\Q * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\E$
+^\Q * See the License for the specific language governing permissions and\E$
+^\Q * limitations under the License.\E$
+^\Q */\E$
+^$
+^.*$

--- a/src/checkstyle/checkstyle-suppressions.xml
+++ b/src/checkstyle/checkstyle-suppressions.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC
+		"-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+		"https://checkstyle.org/dtds/suppressions_1_2.dtd">
+<suppressions>
+	<suppress files="Test.*\.java" checks="MagicNumberCheck" />
+	<suppress files="[\\/]jcohy-boot-configuration-processor[\\/]" checks="AbstractClassNameCheck" />
+	<suppress files="[\\/]src[\\/]test[\\/]java[\\/]" checks="SpringAvoidStaticImport" />
+	<suppress files="[\\/]src[\\/]test[\\/]java[\\/]" checks="NonEmptyAtclauseDescription" />
+</suppressions>

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+		"-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+		"https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="com.puppycrawl.tools.checkstyle.Checker">
+	<property name="localeCountry" value="CN"/>
+	<property name="localeLanguage" value="cn"/>
+	<module name="SuppressionFilter">
+		<property name="file" value="${config_loc}/checkstyle-suppressions.xml"/>
+	</module>
+	<module name="com.jcohy.checkstyle.JcohyChecks">
+		<property name="projectRootPackage" value="com.saga.boot"/>
+		<property name="headerType" value="unchecked" />
+		<property name="style" value="jcohy" />
+	</module>
+
+	<module name="com.puppycrawl.tools.checkstyle.TreeWalker">
+		<module name="com.jcohy.checkstyle.check.SpringJavadocCheck">
+			<property name="publicOnlySinceTags" value="true" />
+			<property name="requireSinceTag" value="true" />
+		</module>
+
+
+		<module name="com.puppycrawl.tools.checkstyle.checks.coding.MagicNumberCheck">
+			<property name="ignoreHashCodeMethod" value="true"/>
+			<property name="ignoreNumbers" value="-1, 0, 1, 2, 4, 8, 10, 16, 32, 64, 1024, 2048"/>
+			<property name="ignoreAnnotation" value="true"/>
+		</module>
+	</module>
+</module>

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -9,7 +9,7 @@
 		<property name="file" value="${config_loc}/checkstyle-suppressions.xml"/>
 	</module>
 	<module name="com.jcohy.checkstyle.JcohyChecks">
-		<property name="projectRootPackage" value="com.saga.boot"/>
+		<property name="projectRootPackage" value="com.jcohy.boot"/>
 		<property name="headerType" value="unchecked" />
 		<property name="style" value="jcohy" />
 	</module>

--- a/src/checkstyle/import-control.xml
+++ b/src/checkstyle/import-control.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<!DOCTYPE import-control PUBLIC "-//Checkstyle//DTD ImportControl Configuration 1.4//EN" "https://checkstyle.org/dtds/import_control_1_4.dtd">
+<import-control pkg="com.saga.boot">
+	<allow pkg=".*" regex="true" />
+<!--	<subpackage name="autoconfigure">-->
+<!--		<subpackage name="web">-->
+<!--			<allow pkg="org.springframework.boot.web.server" />-->
+<!--			<allow pkg="org.springframework.boot.web.servlet.server" />-->
+<!--			<disallow pkg="org.springframework.boot.web" />-->
+<!--			<disallow pkg="org.springframework.web.servlet" />-->
+<!--			<disallow pkg="org.springframework.web.reactive" />-->
+<!--			<disallow pkg="javax.servlet" />-->
+<!--			<subpackage name="client">-->
+<!--				<allow pkg="org.springframework.boot.web.client" />-->
+<!--			</subpackage>-->
+<!--			<subpackage name="embedded">-->
+<!--				<allow pkg="org.springframework.boot.web.embedded" />-->
+<!--			</subpackage>-->
+<!--			<subpackage name="servlet">-->
+<!--				<allow pkg="javax.servlet" />-->
+<!--				<allow pkg="org.springframework.boot.web.embedded" />-->
+<!--				<allow pkg="org.springframework.boot.web.servlet" />-->
+<!--				<allow pkg="org.springframework.web.servlet" />-->
+<!--				<subpackage name="error">-->
+<!--					<allow pkg="org.springframework.boot.web.error" />-->
+<!--				</subpackage>-->
+<!--			</subpackage>-->
+<!--			<subpackage name="reactive">-->
+<!--				<allow pkg="org.springframework.boot.web.codec" />-->
+<!--				<allow pkg="org.springframework.boot.web.embedded" />-->
+<!--				<allow pkg="org.springframework.boot.web.reactive" />-->
+<!--				<allow pkg="org.springframework.web.reactive" />-->
+<!--				<subpackage name="error">-->
+<!--					<allow pkg="org.springframework.boot.web.error" />-->
+<!--				</subpackage>-->
+<!--			</subpackage>-->
+<!--		</subpackage>-->
+<!--	</subpackage>-->
+</import-control>

--- a/src/nohttp/allowlist.lines
+++ b/src/nohttp/allowlist.lines
@@ -1,0 +1,10 @@
+^http://exslt.org/common.*
+^http://ganglia.sourceforge.net.*
+^http://hsqldb.org.*
+^http://livereload.com/.*
+^http://logback.qos.ch/manual/loggingSeparation.html
+^http://schemas.xmlsoap.org/.*
+^http://www.jdotsoft.com.*
+^http://www.liquibase.org/xml/ns/dbchangelog/.*
+^http://www.w3.org/2000/09/xmldsig.*
+^http://192.168.11.*

--- a/src/nohttp/checkstyle.xml
+++ b/src/nohttp/checkstyle.xml
@@ -1,0 +1,13 @@
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+		"https://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<module name="Checker">
+	<property name="charset" value="UTF-8"/>
+	<property name="fileExtensions" value=""/>
+	<module name="io.spring.nohttp.checkstyle.check.NoHttpCheck">
+		<property name="allowlistFileName" value="${config_loc}/allowlist.lines"/>
+	</module>
+	<module name="SuppressionFilter">
+		<property name="file" value="${config_loc}/suppressions.xml"/>
+	</module>
+	<module name="SuppressWithPlainTextCommentFilter"/>
+</module>

--- a/src/nohttp/suppressions.xml
+++ b/src/nohttp/suppressions.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC
+		"-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+		"https://checkstyle.org/dtds/suppressions_1_2.dtd">
+<suppressions>
+	<suppress files="[\\/]transaction-logs[\\/]" checks="NoHttp" />
+	<suppress files="[\\/]build.log" checks="NoHttp" />
+	<suppress files=".+\.(jar|git|ico|p12|gif|jks|jpg|svg)" checks="NoHttp" />
+	<suppress files="jquery.validate.js" checks="NoHttp" />
+	<suppress files="jquery-[0-9]\.[0-9]\.[0-9].js" checks="NoHttp" />
+	<suppress files="[\\/]spring-boot-project.setup" checks="NoHttp" />
+</suppressions>


### PR DESCRIPTION
参考 google 开源的 AutoService 实现代 码的自动生成。详细文档查看: [Google Auto](https://github.com/google/auto)。注意， 此过程是在编译阶段执行的。

- 生成具有 ServiceLoader 配置/元数据样式的生成器。Java 注解处理器和其他系统使用 java.util.ServiceLoader 来提供的 META-INF 元数据注册已知类型的实现
- 我们编写自定义的 Starter 和热部署的时候，通常需要在 /METE-INF  目录下编写相应的配置文件，将需要自动配置的类写入其中。例如 spring.factories 等。所以，我 也将这一过程进行自动化，不用手动编写 spring.factories 文件。自动生成这些文件和配 置项。